### PR TITLE
Fix removed method `async_forward_entry_setup`

### DIFF
--- a/custom_components/nad_controller/__init__.py
+++ b/custom_components/nad_controller/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     for platform in PLATFORMS:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
+            hass.config_entries.async_forward_entry_setups(entry, platform)
         )
 
     return True

--- a/custom_components/nad_controller/__init__.py
+++ b/custom_components/nad_controller/__init__.py
@@ -1,4 +1,5 @@
 """The NAD Cl multi-room audio controller integration."""
+
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -32,13 +33,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = {
         CONF_CLIENT: client,
-        UNDO_UPDATE_LISTENER: undo_listener
+        UNDO_UPDATE_LISTENER: undo_listener,
     }
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(entry, platform)
-        )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    )
 
     return True
 

--- a/custom_components/nad_controller/__init__.py
+++ b/custom_components/nad_controller/__init__.py
@@ -36,9 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UNDO_UPDATE_LISTENER: undo_listener,
     }
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/nad_controller/config_flow.py
+++ b/custom_components/nad_controller/config_flow.py
@@ -12,6 +12,10 @@ from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult, AbortFlow
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_MODEL_NAME,
+    ATTR_UPNP_UDN
+)
 
 from .nad_client import NadClient, DEFAULT_TCP_PORT
 
@@ -132,13 +136,13 @@ class NetworkFlow(ConfigFlow, domain=DOMAIN):
         """
         # Check if required information is present to set the unique_id
         if (
-                ssdp.ATTR_UPNP_MODEL_NAME not in discovery_info.upnp
-                or ssdp.ATTR_UPNP_UDN not in discovery_info.upnp
+                ATTR_UPNP_MODEL_NAME not in discovery_info.upnp
+                or ATTR_UPNP_UDN not in discovery_info.upnp
         ):
             return self.async_abort(reason="not_nad_missing")
 
-        self.model_name = discovery_info.upnp[ssdp.ATTR_UPNP_MODEL_NAME]
-        self.udn = discovery_info.upnp[ssdp.ATTR_UPNP_UDN]
+        self.model_name = discovery_info.upnp[ATTR_UPNP_MODEL_NAME]
+        self.udn = discovery_info.upnp[ATTR_UPNP_UDN]
         self.ip = str(urlparse(discovery_info.ssdp_location).hostname)
         self.port = DEFAULT_TCP_PORT
 

--- a/custom_components/nad_controller/config_flow.py
+++ b/custom_components/nad_controller/config_flow.py
@@ -14,7 +14,8 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult, AbortFlow
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MODEL_NAME,
-    ATTR_UPNP_UDN
+    ATTR_UPNP_UDN,
+    ATTR_UPNP_FRIENDLY_NAME
 )
 
 from .nad_client import NadClient, DEFAULT_TCP_PORT
@@ -161,7 +162,7 @@ class NetworkFlow(ConfigFlow, domain=DOMAIN):
             {
                 "title_placeholders": {
                     "name": discovery_info.upnp.get(
-                        ssdp.ATTR_UPNP_FRIENDLY_NAME, self.ip
+                        ATTR_UPNP_FRIENDLY_NAME, self.ip
                     )
                 }
             }

--- a/custom_components/nad_controller/media_player.py
+++ b/custom_components/nad_controller/media_player.py
@@ -141,7 +141,7 @@ class NadAmp(MediaPlayerEntity):
                 self.update_state_listeners()
             return
 
-        new_state = MediaPlayerState.ON if response.split(':')[1] == "On" else MediaPlayerState.STANDBY
+        new_state = MediaPlayerState.ON if response.split(':')[1] == "On" else MediaPlayerState.OFF
         if new_state != self._attr_state:
             self._attr_state = new_state
             self.update_state_listeners()


### PR DESCRIPTION
`async_forward_entry_setup` was removed (https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/).
Also fixes some deprecation warnings.